### PR TITLE
Fixed IoBuffer.Pointer.setPosition to work in O(1) instead of O(n) in the common case

### DIFF
--- a/codec/src/main/java/org/apache/mina/codec/IoBuffer.java
+++ b/codec/src/main/java/org/apache/mina/codec/IoBuffer.java
@@ -28,19 +28,20 @@ import java.nio.InvalidMarkException;
 import java.nio.ReadOnlyBufferException;
 
 /**
- * A proxy class used to manage ByteBuffers as if they were just a big ByteBuffer. We can add as many buffers as needed,
- * when accumulating data. From the user PoV, the methods are the very same than what we can get from ByteBuffer. <br/>
- * IoBuffer instances are *not* thread safe.
- * 
- * The IoBuffer uses a single-chained queue to handle the multiple Buffers. Thus, the sequential access is 
- * very efficient and the random access is not. It fits well the common usage of IoBuffer.
- * 
+ * A proxy class used to manage ByteBuffers as if they were just a big ByteBuffer. We can add as many buffers as needed
+ * when accumulating data. From the user point of view, the methods are the very same as ByteBuffer provides.
+ *
+ * <p>IoBuffer instances are *not* thread safe.
+ *
+ * <p>The IoBuffer uses a singly linked list to handle the multiple Buffers. Thus sequential access is
+ * very efficient and random access is not. It fits well with the common usage patterns of IoBuffer.
+ *
  * @author <a href="http://mina.apache.org">Apache MINA Project</a>
  */
 public final class IoBuffer {
     private static final int BYTE_MASK = 0xff;
 
-    private static final long BYTE_MASK_L = 0xffl;
+    private static final long BYTE_MASK_L = 0xffL;
 
     /**
      * @see ByteBuffer#allocate(int)
@@ -84,9 +85,9 @@ public final class IoBuffer {
     }
 
     /**
-     * Build new IoBuffer containing 
+     * Wraps ByteBuffers into a new IoBuffer
      * 
-     * @param buffers
+     * @param buffers the ByteBuffers to wrap
      * @return the new {@link IoBuffer}
      */
     public static IoBuffer wrap(ByteBuffer... buffers) {
@@ -126,7 +127,7 @@ public final class IoBuffer {
     /**
      * Add one or more ByteBuffer to the current IoBuffer
      * 
-     * @param buffers
+     * @param buffers the ByteBuffers to add
      * @return the current {@link IoBuffer}
      */
     public IoBuffer add(ByteBuffer... buffers) {
@@ -166,8 +167,8 @@ public final class IoBuffer {
      * Provides an input stream which is actually reading the {@link IoBuffer}
      * instance.
      * <p>
-     * Further reads on the returned inputstream move the reading head of the {@link IoBuffer}
-     * instance used for it's creation</i>
+     * Further reads on the returned InputStream move the reading head of the {@link IoBuffer}
+     * instance used for it's creation
      *
      * @return an input stream
      */
@@ -232,7 +233,7 @@ public final class IoBuffer {
     }
 
     /**
-     * Returns a copy of the current {@link IoBuffer}, with an independent copy if the postion, limit and mark.
+     * Returns a copy of the current {@link IoBuffer}, with an independent copy of the position, limit and mark.
      * 
      * @return the copied {@link IoBuffer}
      */
@@ -580,11 +581,12 @@ public final class IoBuffer {
      * @see ByteBuffer#mark()
      */
     public void mark() {
+        // FIXME: this is broken and untested (it should set the mark instead of limit)
         this.limit = position.duplicate();
     }
 
     /**
-     * Returns the byte order used by this Iouffer when converting bytes from/to other primitive
+     * Returns the byte order used by this IoBuffer when converting bytes from/to other primitive
      * types.
      * <p>
      * The default byte order of byte buffer is always {@link ByteOrder#BIG_ENDIAN BIG_ENDIAN}
@@ -600,7 +602,7 @@ public final class IoBuffer {
     /**
      * Sets the byte order of this IoBuffer.
      * 
-     * @param byteOrder the byte order to set. If {@code null} then the order will be {@link ByteOrder#LITTLE_ENDIAN
+     * @param bo the byte order to set. If {@code null} then the order will be {@link ByteOrder#LITTLE_ENDIAN
      *        LITTLE_ENDIAN}.
      * @return this IoBuffer.
      * @see ByteBuffer#order(ByteOrder)
@@ -826,7 +828,7 @@ public final class IoBuffer {
     }
 
     /**
-     * @see ByteBuffer#putLong(int, int)
+     * @see ByteBuffer#putLong(int, long)
      */
     public IoBuffer putLong(int index, long value) {
         return putLong(getPointerByPosition(index), value);
@@ -933,7 +935,7 @@ public final class IoBuffer {
 
     @Override
     public String toString() {
-        StringBuffer sb = new StringBuffer();
+        StringBuilder sb = new StringBuilder();
         sb.append(getClass().getName());
         sb.append("[pos=");
         sb.append(position());
@@ -1028,7 +1030,7 @@ public final class IoBuffer {
 
         @Override
         public String toString() {
-            StringBuffer sb = new StringBuffer();
+            StringBuilder sb = new StringBuilder();
             sb.append(getClass().getName());
             sb.append("[pos=");
             sb.append(getPosition());

--- a/codec/src/main/java/org/apache/mina/codec/IoBuffer.java
+++ b/codec/src/main/java/org/apache/mina/codec/IoBuffer.java
@@ -998,21 +998,6 @@ public final class IoBuffer {
             return new Pointer(getPosition());
         }
 
-        private BufferNode getBufferNodeByPosition(int pos) {
-            if (head == null) {
-                return null;
-            }
-            BufferNode currentNode = head;
-            int rpos = pos;
-            while (rpos >= currentNode.getBuffer().capacity() && currentNode.hasNext()) {
-
-                rpos -= currentNode.getBuffer().capacity();
-                currentNode = currentNode.getNext();
-            }
-
-            return currentNode;
-        }
-
         public BufferNode getNode() {
             return node;
         }
@@ -1030,11 +1015,7 @@ public final class IoBuffer {
         }
 
         public void setPosition(int newPosition) {
-            if (node == null || node.offset < newPosition) {
-
-                node = getBufferNodeByPosition(newPosition);
-
-            } else {
+            if (node == null || newPosition < node.offset) {
                 node = head;
             }
             positionInBuffer = node == null ? 0 : newPosition - node.offset;

--- a/codec/src/test/java/org/apache/mina/codec/IoBufferPerformanceTest.java
+++ b/codec/src/test/java/org/apache/mina/codec/IoBufferPerformanceTest.java
@@ -1,0 +1,71 @@
+package org.apache.mina.codec;
+
+import org.junit.Test;
+
+import java.nio.ByteBuffer;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class IoBufferPerformanceTest {
+
+    @Test
+    public void testMovingForwardOrNotMovingIsFasterThanMovingBackward() {
+        IoBuffer buffer = IoBuffer.wrap(createByteBuffers(10000, 2));
+
+        long forwardsTime = Integer.MAX_VALUE;
+        long backwardsTime = Integer.MAX_VALUE;
+        long stationaryTime = Integer.MAX_VALUE;
+        for (int i = 0; i < 2; i++) { // one warm-up loop before doing the actual measurement
+
+            long start = System.currentTimeMillis();
+            timeForwards(buffer);
+            long end = System.currentTimeMillis();
+            forwardsTime = end - start;
+
+            start = System.currentTimeMillis();
+            timeBackwards(buffer);
+            end = System.currentTimeMillis();
+            backwardsTime = end - start;
+
+            start = System.currentTimeMillis();
+            timeStationary(buffer);
+            end = System.currentTimeMillis();
+            stationaryTime = end - start;
+        }
+
+        assertMuchFaster("forwards vs. backwards", forwardsTime, backwardsTime);
+        assertMuchFaster("stationary vs. backwards", stationaryTime, backwardsTime);
+    }
+
+    private static void timeForwards(IoBuffer buffer) {
+        for (int i = 0; i < buffer.capacity(); i++) {
+            buffer.position(i);
+        }
+    }
+
+    private static void timeBackwards(IoBuffer buffer) {
+        for (int i = buffer.capacity() - 1; i >= 0; i--) {
+            buffer.position(i);
+        }
+    }
+
+    private static void timeStationary(IoBuffer buffer) {
+        int middle = buffer.capacity() / 2;
+        for (int i = 0; i < buffer.capacity(); i++) {
+            buffer.position(middle);
+        }
+    }
+
+    private static void assertMuchFaster(String message, long faster, long slower) {
+        assertThat(message + ": " + faster + " ms was not much faster than " + slower + " ms",
+                faster < (slower / 10));
+    }
+
+    private static ByteBuffer[] createByteBuffers(int count, int capacity) {
+        ByteBuffer[] buffers = new ByteBuffer[count];
+        for (int i = 0; i < buffers.length; i++) {
+            buffers[i] = ByteBuffer.allocate(capacity);
+        }
+        return buffers;
+    }
+}


### PR DESCRIPTION
IoBuffer.Pointer.setPosition used to always iterate through the singly linked list starting from the very beginning. Here is a fix and a test to reproduce the issue.

There are also some other small refactorings and javadoc fixes (that IntelliJ IDEA's static analysis found - you should try running it also for the rest of the project).

P.S: org.apache.mina.codec.IoBuffer#mark is broken. I'll file an issue for that.
