### PR TITLE
Update the dependency on tomcat-apr/jni (5.5.23 -> 8.0.22)

### DIFF
--- a/mina-transport-apr/pom.xml
+++ b/mina-transport-apr/pom.xml
@@ -38,8 +38,8 @@
     </dependency>
 
     <dependency>
-      <groupId>tomcat</groupId>
-      <artifactId>tomcat-apr</artifactId>
+      <groupId>org.apache.tomcat</groupId>
+      <artifactId>tomcat-jni</artifactId>
     </dependency>
   </dependencies>
 

--- a/mina-transport-apr/src/main/java/org/apache/mina/transport/socket/apr/AprLibrary.java
+++ b/mina-transport-apr/src/main/java/org/apache/mina/transport/socket/apr/AprLibrary.java
@@ -76,8 +76,8 @@ class AprLibrary {
     private AprLibrary() {
         try {
             Library.initialize(null);
-        } catch (Exception e) {
-            throw new RuntimeException("Error loading Apache Portable Runtime (APR).", e);
+        } catch (Throwable t) {
+            throw new RuntimeException("Error loading Apache Portable Runtime (APR).", t);
         }
         pool = Pool.create(0);
     }

--- a/pom.xml
+++ b/pom.xml
@@ -152,7 +152,7 @@
     <version.slf4j.log4j12>1.7.7</version.slf4j.log4j12>
     <version.slf4j.jcl.over.slf4j>1.7.7</version.slf4j.jcl.over.slf4j>
     <version.springframework>2.5.6.SEC03</version.springframework>
-    <version.tomcat.apr>5.5.23</version.tomcat.apr>
+    <version.tomcat.apr>8.0.22</version.tomcat.apr>
     <version.xbean.spring>4.0</version.xbean.spring>
   </properties>
 
@@ -228,8 +228,8 @@
 
       <!-- Transport -->
       <dependency>
-        <groupId>tomcat</groupId>
-        <artifactId>tomcat-apr</artifactId>
+        <groupId>org.apache.tomcat</groupId>
+        <artifactId>tomcat-jni</artifactId>
         <version>${version.tomcat.apr}</version>
       </dependency>
 


### PR DESCRIPTION
Hi,

mina-transport-apr no longer builds against Tomcat 8, here is a patch fixing this.
