### PR TITLE
Remove the dependency on easymockclassextension

### DIFF
--- a/mina-core/pom.xml
+++ b/mina-core/pom.xml
@@ -36,11 +36,6 @@
       <groupId>org.easymock</groupId>
       <artifactId>easymock</artifactId>
     </dependency>
-    
-    <dependency>
-      <groupId>org.easymock</groupId>
-      <artifactId>easymockclassextension</artifactId>
-    </dependency>
   </dependencies>
   
   <build>

--- a/mina-core/src/test/java/org/apache/mina/filter/stream/AbstractStreamWriteFilterTest.java
+++ b/mina-core/src/test/java/org/apache/mina/filter/stream/AbstractStreamWriteFilterTest.java
@@ -47,7 +47,7 @@ import org.apache.mina.transport.socket.nio.NioSocketAcceptor;
 import org.apache.mina.transport.socket.nio.NioSocketConnector;
 import org.apache.mina.util.AvailablePortFinder;
 import org.easymock.IArgumentMatcher;
-import org.easymock.classextension.EasyMock;
+import org.easymock.EasyMock;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/pom.xml
+++ b/pom.xml
@@ -138,7 +138,6 @@
     <!-- Jars -->
     <version.commons.lang>2.6</version.commons.lang>
     <version.easymock>2.5.2</version.easymock>
-    <version.easymockclassextension>2.5.2</version.easymockclassextension>
     <version.jboss.javassist>3.7.ga</version.jboss.javassist>
     <version.jdom>1.0</version.jdom>
     <version.jmock>1.2.0</version.jmock>
@@ -344,13 +343,6 @@
         <groupId>org.easymock</groupId>
         <artifactId>easymock</artifactId>
         <version>${version.easymock}</version>
-        <scope>test</scope>
-      </dependency>
-
-      <dependency>
-        <groupId>org.easymock</groupId>
-        <artifactId>easymockclassextension</artifactId>
-        <version>${version.easymockclassextension}</version>
         <scope>test</scope>
       </dependency>
 


### PR DESCRIPTION
easymockclassextension is obsolete and can be removed
