### PR TITLE
Set maximum before core. Fix for JDK10

### DIFF
--- a/mina-core/src/main/java/org/apache/mina/filter/executor/OrderedThreadPoolExecutor.java
+++ b/mina-core/src/main/java/org/apache/mina/filter/executor/OrderedThreadPoolExecutor.java
@@ -197,8 +197,8 @@ public class OrderedThreadPoolExecutor extends ThreadPoolExecutor {
         }
 
         // Now, we can setup the pool sizes
-        super.setCorePoolSize(corePoolSize);
         super.setMaximumPoolSize(maximumPoolSize);
+        super.setCorePoolSize(corePoolSize);
 
         // The queueHandler might be null.
         if (eventQueueHandler == null) {


### PR DESCRIPTION
There is a problem with Java 10 when the core is set before the maximum.