### PR TITLE
DIRMINA-1126 : filterWrite in ProtocolCodecFilter can send corrupted writeRequest message to the next filter

### DIFF
--- a/mina-core/src/main/java/org/apache/mina/filter/codec/ProtocolCodecFilter.java
+++ b/mina-core/src/main/java/org/apache/mina/filter/codec/ProtocolCodecFilter.java
@@ -335,9 +335,9 @@ public class ProtocolCodecFilter extends IoFilterAdapter {
 
                 // Flush only when the buffer has remaining.
                 if (!(encodedMessage instanceof IoBuffer) || ((IoBuffer) encodedMessage).hasRemaining()) {
-                    writeRequest.setMessage(encodedMessage);
-
-                    nextFilter.filterWrite(session, writeRequest);
+                    SocketAddress destination = writeRequest.getDestination();
+                    WriteRequest encodedWriteRequest = new EncodedWriteRequest(encodedMessage, null, destination);
+                    nextFilter.filterWrite(session, encodedWriteRequest);
                 }
             }
         } catch (Exception e) {

--- a/mina-core/src/main/java/org/apache/mina/filter/ssl/SslContextFactory.java
+++ b/mina-core/src/main/java/org/apache/mina/filter/ssl/SslContextFactory.java
@@ -36,7 +36,7 @@ import javax.net.ssl.TrustManagerFactory;
  * If no properties are set the returned {@link SSLContext} will
  * be equivalent to what the following creates:
  * <pre>
- *      SSLContext c = SSLContext.getInstance( "TLS" );
+ *      SSLContext c = SSLContext.getInstance( "TLSv1.2" );
  *      c.init(null, null, null);
  * </pre>
  * <p>
@@ -52,7 +52,7 @@ public class SslContextFactory {
 
     private String provider = null;
 
-    private String protocol = "TLS";
+    private String protocol = "TLSv1.2";
 
     private SecureRandom secureRandom = null;
 

--- a/mina-core/src/main/java/org/apache/mina/transport/socket/nio/NioDatagramAcceptor.java
+++ b/mina-core/src/main/java/org/apache/mina/transport/socket/nio/NioDatagramAcceptor.java
@@ -896,8 +896,10 @@ public final class NioDatagramAcceptor extends AbstractIoAcceptor implements Dat
                     // Kernel buffer is full or wrote too much
                     setInterestedInWrite(session, true);
 
-                    session.getWriteRequestQueue().offer(session, writeRequest);
+                    writeRequestQueue.offer(session, writeRequest);
                     scheduleFlush(session);
+                    
+                    break;
                 } else {
                     setInterestedInWrite(session, false);
 

--- a/mina-core/src/main/java/org/apache/mina/transport/socket/nio/NioSocketAcceptor.java
+++ b/mina-core/src/main/java/org/apache/mina/transport/socket/nio/NioSocketAcceptor.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.ServerSocket;
 import java.net.SocketAddress;
+import java.net.StandardSocketOptions;
 import java.nio.channels.SelectionKey;
 import java.nio.channels.Selector;
 import java.nio.channels.ServerSocketChannel;
@@ -40,6 +41,7 @@ import org.apache.mina.core.service.SimpleIoProcessorPool;
 import org.apache.mina.core.service.TransportMetadata;
 import org.apache.mina.transport.socket.DefaultSocketSessionConfig;
 import org.apache.mina.transport.socket.SocketAcceptor;
+import org.apache.mina.transport.socket.SocketSessionConfig;
 
 /**
  * {@link IoAcceptor} for socket transport (TCP/IP).  This class
@@ -226,6 +228,8 @@ implements SocketAcceptor {
     protected ServerSocketChannel open(SocketAddress localAddress) throws Exception {
         // Creates the listening ServerSocket
 
+	SocketSessionConfig config = this.getSessionConfig();
+	
         ServerSocketChannel channel = null;
 
         if (selectorProvider != null) {
@@ -245,6 +249,16 @@ implements SocketAcceptor {
 
             // Set the reuseAddress flag accordingly with the setting
             socket.setReuseAddress(isReuseAddress());
+            
+            // Set the SND BUFF
+	    if (config.getSendBufferSize() != -1) {
+		channel.setOption(StandardSocketOptions.SO_SNDBUF, config.getSendBufferSize());
+	    }
+
+	    // Set the RCV BUFF
+	    if (config.getReceiveBufferSize() != -1) {
+		channel.setOption(StandardSocketOptions.SO_RCVBUF, config.getReceiveBufferSize());
+	    }
 
             // and bind.
             try {


### PR DESCRIPTION
This change in 2.1.1 introduced new errors coming from clients that they can decode messages.
More details in the task:
https://issues.apache.org/jira/browse/DIRMINA-1126
