### PR TITLE
2.1.x

### DIFF
--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <artifactId>mina-parent</artifactId>
     <groupId>org.apache.mina</groupId>
-    <version>2.1.4-SNAPSHOT</version>
+    <version>2.1.4-PSG</version>
   </parent>
 
   <artifactId>distribution</artifactId>

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <artifactId>mina-parent</artifactId>
     <groupId>org.apache.mina</groupId>
-    <version>2.1.4-PSG</version>
+    <version>2.1.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>distribution</artifactId>

--- a/mina-core/pom.xml
+++ b/mina-core/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.apache.mina</groupId>
     <artifactId>mina-parent</artifactId>
-    <version>2.1.4-SNAPSHOT</version>
+    <version>2.1.4-PSG</version>
   </parent>
 
   <artifactId>mina-core</artifactId>

--- a/mina-core/pom.xml
+++ b/mina-core/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.apache.mina</groupId>
     <artifactId>mina-parent</artifactId>
-    <version>2.1.4-PSG</version>
+    <version>2.1.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>mina-core</artifactId>

--- a/mina-core/src/main/java/org/apache/mina/core/filterchain/IoFilterEvent.java
+++ b/mina-core/src/main/java/org/apache/mina/core/filterchain/IoFilterEvent.java
@@ -19,6 +19,7 @@
  */
 package org.apache.mina.core.filterchain;
 
+import org.apache.mina.core.buffer.IoBuffer;
 import org.apache.mina.core.filterchain.IoFilter.NextFilter;
 import org.apache.mina.core.session.IdleStatus;
 import org.apache.mina.core.session.IoEvent;
@@ -104,6 +105,7 @@ public class IoFilterEvent extends IoEvent {
             case MESSAGE_RECEIVED:
                 Object parameter = getParameter();
                 nextFilter.messageReceived(session, parameter);
+                if (parameter instanceof IoBuffer) ((IoBuffer)parameter).free();
                 break;
     
             case MESSAGE_SENT:

--- a/mina-core/src/main/java/org/apache/mina/core/polling/AbstractPollingIoProcessor.java
+++ b/mina-core/src/main/java/org/apache/mina/core/polling/AbstractPollingIoProcessor.java
@@ -537,12 +537,15 @@ public abstract class AbstractPollingIoProcessor<S extends AbstractIoSession> im
             if (readBytes > 0) {
                 IoFilterChain filterChain = session.getFilterChain();
                 filterChain.fireMessageReceived(buf);
+                buf.free();
                 buf = null;
 
                 if (hasFragmentation) {
                     if (readBytes << 1 < config.getReadBufferSize()) {
+                    	if (LOG.isDebugEnabled()) LOG.debug("Decrease read buffer size: current: " + config.getReadBufferSize());
                         session.decreaseReadBufferSize();
                     } else if (readBytes == config.getReadBufferSize()) {
+                    	if (LOG.isDebugEnabled()) LOG.debug("Increase read buffer size: current: " + config.getReadBufferSize());
                         session.increaseReadBufferSize();
                     }
                 }

--- a/mina-core/src/main/java/org/apache/mina/filter/codec/AbstractProtocolEncoderOutput.java
+++ b/mina-core/src/main/java/org/apache/mina/filter/codec/AbstractProtocolEncoderOutput.java
@@ -57,7 +57,7 @@ public abstract class AbstractProtocolEncoderOutput implements ProtocolEncoderOu
         if (encodedMessage instanceof IoBuffer) {
             IoBuffer buf = (IoBuffer) encodedMessage;
             if (buf.hasRemaining()) {
-                messageQueue.offer(buf);
+                messageQueue.offer(buf.duplicate());
             } else {
                 throw new IllegalArgumentException("buf is empty. Forgot to call flip()?");
             }

--- a/mina-core/src/main/java/org/apache/mina/filter/codec/AbstractProtocolEncoderOutput.java
+++ b/mina-core/src/main/java/org/apache/mina/filter/codec/AbstractProtocolEncoderOutput.java
@@ -100,6 +100,7 @@ public abstract class AbstractProtocolEncoderOutput implements ProtocolEncoderOu
             }
 
             newBuf.put(buf);
+			buf.free();
         }
 
         // Push the new buffer finally.

--- a/mina-core/src/main/java/org/apache/mina/filter/codec/CumulativeProtocolDecoder.java
+++ b/mina-core/src/main/java/org/apache/mina/filter/codec/CumulativeProtocolDecoder.java
@@ -165,9 +165,12 @@ public abstract class CumulativeProtocolDecoder extends ProtocolDecoderAdapter {
                 newBuf.put(buf);
                 newBuf.put(in);
                 newBuf.flip();
+				buf.free();
                 buf = newBuf;
 
                 // Update the session attribute.
+				IoBuffer oldBuf = (IoBuffer) session.getAttribute(BUFFER);
+				if (oldBuf != null) oldBuf.free();
                 session.setAttribute(BUFFER, buf);
             }
         } else {
@@ -234,8 +237,9 @@ public abstract class CumulativeProtocolDecoder extends ProtocolDecoderAdapter {
     }
 
     private void removeSessionBuffer(IoSession session) {
-        session.removeAttribute(BUFFER);
-    }
+        IoBuffer oldBuf = (IoBuffer) session.removeAttribute(BUFFER);
+ 		if (oldBuf != null) oldBuf.free();
+   }
 
     private void storeRemainingInSession(IoBuffer buf, IoSession session) {
         final IoBuffer remainingBuf = IoBuffer.allocate(buf.capacity()).setAutoExpand(true);
@@ -243,6 +247,8 @@ public abstract class CumulativeProtocolDecoder extends ProtocolDecoderAdapter {
         remainingBuf.order(buf.order());
         remainingBuf.put(buf);
 
+		IoBuffer oldBuf = (IoBuffer) session.getAttribute(BUFFER);
+		if (oldBuf != null) oldBuf.free();
         session.setAttribute(BUFFER, remainingBuf);
     }
     

--- a/mina-core/src/main/java/org/apache/mina/filter/codec/CumulativeProtocolDecoder.java
+++ b/mina-core/src/main/java/org/apache/mina/filter/codec/CumulativeProtocolDecoder.java
@@ -169,8 +169,8 @@ public abstract class CumulativeProtocolDecoder extends ProtocolDecoderAdapter {
                 buf = newBuf;
 
                 // Update the session attribute.
-				IoBuffer oldBuf = (IoBuffer) session.getAttribute(BUFFER);
-				if (oldBuf != null) oldBuf.free();
+				//IoBuffer oldBuf = (IoBuffer) session.getAttribute(BUFFER);
+				//if (oldBuf != null) oldBuf.free();
                 session.setAttribute(BUFFER, buf);
             }
         } else {
@@ -247,8 +247,8 @@ public abstract class CumulativeProtocolDecoder extends ProtocolDecoderAdapter {
         remainingBuf.order(buf.order());
         remainingBuf.put(buf);
 
-		IoBuffer oldBuf = (IoBuffer) session.getAttribute(BUFFER);
-		if (oldBuf != null) oldBuf.free();
+        IoBuffer oldBuf = (IoBuffer) session.removeAttribute(BUFFER);
+  		if (oldBuf != null) oldBuf.free();
         session.setAttribute(BUFFER, remainingBuf);
     }
     

--- a/mina-core/src/main/java/org/apache/mina/filter/codec/ProtocolCodecFilter.java
+++ b/mina-core/src/main/java/org/apache/mina/filter/codec/ProtocolCodecFilter.java
@@ -281,7 +281,7 @@ public class ProtocolCodecFilter extends IoFilterAdapter {
                 }
             }
         }
-		in.free();
+		//in.free();
     }
 
     /**

--- a/mina-core/src/main/java/org/apache/mina/filter/codec/ProtocolCodecFilter.java
+++ b/mina-core/src/main/java/org/apache/mina/filter/codec/ProtocolCodecFilter.java
@@ -281,6 +281,7 @@ public class ProtocolCodecFilter extends IoFilterAdapter {
                 }
             }
         }
+		in.free();
     }
 
     /**

--- a/mina-core/src/main/java/org/apache/mina/filter/executor/ExecutorFilter.java
+++ b/mina-core/src/main/java/org/apache/mina/filter/executor/ExecutorFilter.java
@@ -26,6 +26,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 
+import org.apache.mina.core.buffer.IoBuffer;
 import org.apache.mina.core.filterchain.IoFilterAdapter;
 import org.apache.mina.core.filterchain.IoFilterChain;
 import org.apache.mina.core.filterchain.IoFilterEvent;
@@ -563,8 +564,13 @@ public class ExecutorFilter extends IoFilterAdapter {
     @Override
     public final void messageReceived(NextFilter nextFilter, IoSession session, Object message) {
         if (eventTypes.contains(IoEventType.MESSAGE_RECEIVED)) {
-            IoFilterEvent event = new IoFilterEvent(nextFilter, IoEventType.MESSAGE_RECEIVED, session, message);
-            fireEvent(event);
+        	if (message instanceof IoBuffer) {
+        		IoFilterEvent event = new IoFilterEvent(nextFilter, IoEventType.MESSAGE_RECEIVED, session, ((IoBuffer)message).duplicate());
+        		fireEvent(event);
+        	} else {
+                IoFilterEvent event = new IoFilterEvent(nextFilter, IoEventType.MESSAGE_RECEIVED, session, message);
+                fireEvent(event);
+        	}
         } else {
             nextFilter.messageReceived(session, message);
         }

--- a/mina-example/pom.xml
+++ b/mina-example/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.apache.mina</groupId>
     <artifactId>mina-parent</artifactId>
-    <version>2.1.4-SNAPSHOT</version>
+    <version>2.1.4-PSG</version>
   </parent>
 
   <artifactId>mina-example</artifactId>

--- a/mina-example/pom.xml
+++ b/mina-example/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.apache.mina</groupId>
     <artifactId>mina-parent</artifactId>
-    <version>2.1.4-PSG</version>
+    <version>2.1.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>mina-example</artifactId>

--- a/mina-filter-compression/pom.xml
+++ b/mina-filter-compression/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.apache.mina</groupId>
     <artifactId>mina-parent</artifactId>
-    <version>2.1.4-SNAPSHOT</version>
+    <version>2.1.4-PSG</version>
   </parent>
 
   <artifactId>mina-filter-compression</artifactId>

--- a/mina-filter-compression/pom.xml
+++ b/mina-filter-compression/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.apache.mina</groupId>
     <artifactId>mina-parent</artifactId>
-    <version>2.1.4-PSG</version>
+    <version>2.1.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>mina-filter-compression</artifactId>

--- a/mina-http/pom.xml
+++ b/mina-http/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.apache.mina</groupId>
     <artifactId>mina-parent</artifactId>
-    <version>2.1.4-PSG</version>
+    <version>2.1.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>mina-http</artifactId>

--- a/mina-http/pom.xml
+++ b/mina-http/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.apache.mina</groupId>
     <artifactId>mina-parent</artifactId>
-    <version>2.1.4-SNAPSHOT</version>
+    <version>2.1.4-PSG</version>
   </parent>
 
   <artifactId>mina-http</artifactId>

--- a/mina-integration-beans/pom.xml
+++ b/mina-integration-beans/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.apache.mina</groupId>
     <artifactId>mina-parent</artifactId>
-    <version>2.1.4-SNAPSHOT</version>
+    <version>2.1.4-PSG</version>
   </parent>
 
   <artifactId>mina-integration-beans</artifactId>

--- a/mina-integration-beans/pom.xml
+++ b/mina-integration-beans/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.apache.mina</groupId>
     <artifactId>mina-parent</artifactId>
-    <version>2.1.4-PSG</version>
+    <version>2.1.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>mina-integration-beans</artifactId>

--- a/mina-integration-jmx/pom.xml
+++ b/mina-integration-jmx/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.apache.mina</groupId>
     <artifactId>mina-parent</artifactId>
-    <version>2.1.4-SNAPSHOT</version>
+    <version>2.1.4-PSG</version>
   </parent>
 
   <artifactId>mina-integration-jmx</artifactId>

--- a/mina-integration-jmx/pom.xml
+++ b/mina-integration-jmx/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.apache.mina</groupId>
     <artifactId>mina-parent</artifactId>
-    <version>2.1.4-PSG</version>
+    <version>2.1.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>mina-integration-jmx</artifactId>

--- a/mina-integration-ognl/pom.xml
+++ b/mina-integration-ognl/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.apache.mina</groupId>
     <artifactId>mina-parent</artifactId>
-    <version>2.1.4-PSG</version>
+    <version>2.1.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>mina-integration-ognl</artifactId>

--- a/mina-integration-ognl/pom.xml
+++ b/mina-integration-ognl/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.apache.mina</groupId>
     <artifactId>mina-parent</artifactId>
-    <version>2.1.4-SNAPSHOT</version>
+    <version>2.1.4-PSG</version>
   </parent>
 
   <artifactId>mina-integration-ognl</artifactId>

--- a/mina-integration-xbean/pom.xml
+++ b/mina-integration-xbean/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.apache.mina</groupId>
     <artifactId>mina-parent</artifactId>
-    <version>2.1.4-PSG</version>
+    <version>2.1.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>mina-integration-xbean</artifactId>

--- a/mina-integration-xbean/pom.xml
+++ b/mina-integration-xbean/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.apache.mina</groupId>
     <artifactId>mina-parent</artifactId>
-    <version>2.1.4-SNAPSHOT</version>
+    <version>2.1.4-PSG</version>
   </parent>
 
   <artifactId>mina-integration-xbean</artifactId>

--- a/mina-legal/pom.xml
+++ b/mina-legal/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.mina</groupId>
         <artifactId>mina-parent</artifactId>
-        <version>2.1.4-SNAPSHOT</version>
+        <version>2.1.4-PSG</version>
     </parent>
 
     <artifactId>mina-legal</artifactId>

--- a/mina-legal/pom.xml
+++ b/mina-legal/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.mina</groupId>
         <artifactId>mina-parent</artifactId>
-        <version>2.1.4-PSG</version>
+        <version>2.1.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>mina-legal</artifactId>

--- a/mina-statemachine/pom.xml
+++ b/mina-statemachine/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.apache.mina</groupId>
     <artifactId>mina-parent</artifactId>
-    <version>2.1.4-PSG</version>
+    <version>2.1.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>mina-statemachine</artifactId>

--- a/mina-statemachine/pom.xml
+++ b/mina-statemachine/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.apache.mina</groupId>
     <artifactId>mina-parent</artifactId>
-    <version>2.1.4-SNAPSHOT</version>
+    <version>2.1.4-PSG</version>
   </parent>
 
   <artifactId>mina-statemachine</artifactId>

--- a/mina-transport-apr/pom.xml
+++ b/mina-transport-apr/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.mina</groupId>
     <artifactId>mina-parent</artifactId>
-    <version>2.1.4-SNAPSHOT</version>
+    <version>2.1.4-PSG</version>
   </parent>
 
   <artifactId>mina-transport-apr</artifactId>

--- a/mina-transport-apr/pom.xml
+++ b/mina-transport-apr/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.mina</groupId>
     <artifactId>mina-parent</artifactId>
-    <version>2.1.4-PSG</version>
+    <version>2.1.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>mina-transport-apr</artifactId>

--- a/mina-transport-serial/pom.xml
+++ b/mina-transport-serial/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.apache.mina</groupId>
     <artifactId>mina-parent</artifactId>
-    <version>2.1.4-SNAPSHOT</version>
+    <version>2.1.4-PSG</version>
   </parent>
 
   <artifactId>mina-transport-serial</artifactId>

--- a/mina-transport-serial/pom.xml
+++ b/mina-transport-serial/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.apache.mina</groupId>
     <artifactId>mina-parent</artifactId>
-    <version>2.1.4-PSG</version>
+    <version>2.1.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>mina-transport-serial</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
   </organization>
 
   <groupId>org.apache.mina</groupId>
-  <version>2.1.4-SNAPSHOT</version>
+  <version>2.1.4-PSG</version>
   <artifactId>mina-parent</artifactId>
   <name>Apache MINA</name>
   <packaging>pom</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
   </organization>
 
   <groupId>org.apache.mina</groupId>
-  <version>2.1.4-PSG</version>
+  <version>2.1.4-SNAPSHOT</version>
   <artifactId>mina-parent</artifactId>
   <name>Apache MINA</name>
   <packaging>pom</packaging>


### PR DESCRIPTION
There were some places where buffers were not properly duplicated and/or freed. This caused poor performance when attempting to cache IOBuffers.