### PR TITLE
workaround for Reproducible Builds

### DIFF
--- a/mina-integration-xbean/pom.xml
+++ b/mina-integration-xbean/pom.xml
@@ -110,6 +110,32 @@
           </execution>
         </executions>
       </plugin>
+      <plugin><!-- workaround for https://issues.apache.org/jira/browse/XBEAN-335 -->
+        <groupId>com.google.code.maven-replacer-plugin</groupId>
+        <artifactId>replacer</artifactId>
+        <version>1.5.3</version>
+        <executions>
+          <execution>
+            <phase>generate-sources</phase>
+            <goals>
+              <goal>replace</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <basedir>${project.build.directory}/xbean/META-INF</basedir>
+          <includes>
+            <include>spring.*</include>
+          </includes>
+          <replacements>
+            <replacement>
+              <token>#... ... .+</token>
+              <value>#</value>
+            </replacement>
+          </replacements>
+          <regex>true</regex>
+        </configuration>
+      </plugin>
 
       <!--  lets ensure that the XSD gets deployed  -->
       <plugin>


### PR DESCRIPTION
XBean Spring produces non reproducible output, as seen when rebuilding Mina releases https://github.com/jvm-repo-rebuild/reproducible-central/blob/master/content/org/apache/mina/README.md

waiting for XBean to fix the issue, we can do a workaround: detect and remove the timestamp

then next Mina release will be fully Reproducible