### PR TITLE
[DIRMINA-1169] Fix unbinding a serverSocketChannel

### DIFF
--- a/mina-core/src/main/java/org/apache/mina/transport/socket/nio/NioSocketAcceptor.java
+++ b/mina-core/src/main/java/org/apache/mina/transport/socket/nio/NioSocketAcceptor.java
@@ -66,7 +66,7 @@ public  class NioSocketAcceptor extends AbstractPollingIoAcceptor<NioSession, Se
     /**
      * Constructor for {@link NioSocketAcceptor} using default parameters, and
      * given number of {@link NioProcessor} for multithreading I/O operations.
-     * 
+     *
      * @param processorCount the number of processor to create and place in a
      * {@link SimpleIoProcessorPool}
      */
@@ -148,6 +148,7 @@ public  class NioSocketAcceptor extends AbstractPollingIoAcceptor<NioSession, Se
     /**
      * {@inheritDoc}
      */
+    @Override
     public TransportMetadata getTransportMetadata() {
         return NioSocketSession.METADATA;
     }
@@ -171,6 +172,7 @@ public  class NioSocketAcceptor extends AbstractPollingIoAcceptor<NioSession, Se
     /**
      * {@inheritDoc}
      */
+    @Override
     public void setDefaultLocalAddress(InetSocketAddress localAddress) {
         setDefaultLocalAddress((SocketAddress) localAddress);
     }
@@ -194,7 +196,7 @@ public  class NioSocketAcceptor extends AbstractPollingIoAcceptor<NioSession, Se
         // accept the connection from the client
         try {
             SocketChannel ch = handle.accept();
-    
+
             if (ch == null) {
                 return null;
             }
@@ -260,21 +262,21 @@ public  class NioSocketAcceptor extends AbstractPollingIoAcceptor<NioSession, Se
                 channel.setOption(StandardSocketOptions.SO_RCVBUF, config.getReceiveBufferSize());
             }
 
-      
+
             // and bind.
             try {
                 socket.bind(localAddress, getBacklog());
             } catch (IOException ioe) {
                 // Add some info regarding the address we try to bind to the
                 // message
-                String newMessage = "Error while binding on " + localAddress + "\n" + "original message : "
-                        + ioe.getMessage();
+                String newMessage = "Error while binding on " + localAddress;
                 Exception e = new IOException(newMessage, ioe);
-                e.initCause(ioe.getCause());
-
-                // And close the channel
-                channel.close();
-
+                try {
+                    // And close the channel
+                    channel.close();
+                } catch (IOException nested) {
+                    e.addSuppressed(nested);
+                }
                 throw e;
             }
 
@@ -305,7 +307,7 @@ public  class NioSocketAcceptor extends AbstractPollingIoAcceptor<NioSession, Se
      * It returns only after at least one channel is selected,
      * this selector's wakeup method is invoked, or the current thread
      * is interrupted, whichever comes first.
-     * 
+     *
      * @return The number of keys having their ready-operation set updated
      * @throws IOException If an I/O error occurs
      */
@@ -355,7 +357,7 @@ public  class NioSocketAcceptor extends AbstractPollingIoAcceptor<NioSession, Se
         /**
          * Build a SocketChannel iterator which will return a SocketChannel instead of
          * a SelectionKey.
-         * 
+         *
          * @param selectedKeys The selector selected-key set
          */
         private ServerSocketChannelIterator(Collection<SelectionKey> selectedKeys) {
@@ -367,6 +369,7 @@ public  class NioSocketAcceptor extends AbstractPollingIoAcceptor<NioSession, Se
          * @return <tt>true</tt> if there is at least one more
          * SockectChannel object to read
          */
+        @Override
         public boolean hasNext() {
             return iterator.hasNext();
         }
@@ -374,9 +377,10 @@ public  class NioSocketAcceptor extends AbstractPollingIoAcceptor<NioSession, Se
         /**
          * Get the next SocketChannel in the operator we have built from
          * the selected-key et for this selector.
-         * 
+         *
          * @return The next SocketChannel in the iterator
          */
+        @Override
         public ServerSocketChannel next() {
             SelectionKey key = iterator.next();
 
@@ -390,6 +394,7 @@ public  class NioSocketAcceptor extends AbstractPollingIoAcceptor<NioSession, Se
         /**
          * Remove the current SocketChannel from the iterator
          */
+        @Override
         public void remove() {
             iterator.remove();
         }

--- a/mina-core/src/test/java/org/apache/mina/transport/socket/nio/SocketAcceptorTest.java
+++ b/mina-core/src/test/java/org/apache/mina/transport/socket/nio/SocketAcceptorTest.java
@@ -1,0 +1,71 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ *
+ */
+package org.apache.mina.transport.socket.nio;
+
+import java.net.InetSocketAddress;
+import java.util.Collection;
+import java.util.concurrent.CountDownLatch;
+
+import org.apache.mina.core.service.IoHandlerAdapter;
+import org.apache.mina.util.AvailablePortFinder;
+import org.junit.Test;
+
+public class SocketAcceptorTest {
+
+    @Test
+    public void testBindTwice() throws Exception {
+        NioSocketAcceptor acceptor = new NioSocketAcceptor() {
+
+            private int nRequests;
+
+            private CountDownLatch secondRequestAdded = new CountDownLatch(1);
+
+            @Override
+            protected void bindRequestAdded() {
+                super.bindRequestAdded();
+                nRequests++;
+                if (nRequests == 2) {
+                    secondRequestAdded.countDown();
+                }
+            }
+
+            @Override
+            protected void handleUnbound(Collection<AcceptorOperationFuture> unboundFutures) throws Exception {
+                super.handleUnbound(unboundFutures);
+                if (!unboundFutures.isEmpty() && nRequests == 1) {
+                    secondRequestAdded.await();
+                }
+            }
+        };
+        acceptor.setCloseOnDeactivation(false);
+        acceptor.setReuseAddress(true);
+        acceptor.setHandler(new IoHandlerAdapter());
+        try {
+            int port = AvailablePortFinder.getNextAvailable(1025);
+            InetSocketAddress address = new InetSocketAddress("127.0.0.1", port);
+            acceptor.bind(address);
+            acceptor.unbind(address);
+            acceptor.bind(address);
+            acceptor.unbind(address);
+        } finally {
+            acceptor.dispose();
+        }
+    }
+}


### PR DESCRIPTION
Since Java 11, closing a ServerSocketChannel may release the socket
only on the next select() call. If we try to register a new binding for
an unbound socket before the next select, a BindException may be thrown.

Ensure that there is a select() call between unbinding some sockets and
binding new sockets. Mark the unbind futures as "done" only after that
intervening select().

Test plan:
- check out this PR
- replace NioSocketAcceptor by the 2.0.23 version
- run the SocketAcceptorTest on a JVM 11 (or newer). It should fail with a BindException.
- git reset --hard
- run the SocketAcceptorTest on a JVM 11 (or newer) again. It should pass.

Note that if SocketAcceptorTest is run on a JVM 8, it will succeed in either case.