### PR TITLE
write direct buffer only once in APR

### DIFF
--- a/mina-transport-apr/src/main/java/org/apache/mina/transport/socket/apr/AprIoProcessor.java
+++ b/mina-transport-apr/src/main/java/org/apache/mina/transport/socket/apr/AprIoProcessor.java
@@ -434,9 +434,9 @@ public final class AprIoProcessor extends AbstractPollingIoProcessor<AprSession>
             writtenBytes = Socket.sendb(session.getDescriptor(), buf.buf(), buf.position(), length);
         } else {
             writtenBytes = Socket.send(session.getDescriptor(), buf.array(), buf.position(), length);
-            if (writtenBytes > 0) {
-                buf.skip(writtenBytes);
-            }
+        }
+        if (writtenBytes > 0) {
+            buf.skip(writtenBytes);
         }
 
         if (writtenBytes < 0) {


### PR DESCRIPTION
fixes an endless loop when writing a direct buffer in APR