### PR TITLE
Fix patch application for DIRMINA-1169

### DIFF
--- a/mina-core/src/main/java/org/apache/mina/transport/socket/nio/NioSocketAcceptor.java
+++ b/mina-core/src/main/java/org/apache/mina/transport/socket/nio/NioSocketAcceptor.java
@@ -139,6 +139,35 @@ implements SocketAcceptor {
      * {@inheritDoc}
      */
     @Override
+    protected void handleUnbound(Collection<AcceptorOperationFuture> unboundFutures) throws Exception {
+        // If we're on Java >= 11, unbindings may take effect only on the next select()
+        // TODO: add a check (java.specification.version?) to do this only on a JVM >= 11?
+        if (!unboundFutures.isEmpty()) {
+            int selected = 0;
+            try {
+                // Simply select() would also work since wakeup() *was* called, but let's be explicit.
+                selected = selector.selectNow();
+            } finally {
+                super.handleUnbound(unboundFutures); // Marks the futures as done
+                if (hasUnbindings()) {
+                    // Depending on when these new unbindings were added, their wakeup() call may just have been
+                    // cancelled by the above select. Re-instate it, so that the next select will not block, as
+                    // expected.
+                    wakeup();
+                }
+            }
+            if (selected > 0) {
+                processHandles(selectedHandles());
+            }
+        } else {
+            super.handleUnbound(unboundFutures);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     protected void destroy() throws Exception {
         if (selector != null) {
             selector.close();


### PR DESCRIPTION
Add the most crucial bit: the actual fix. Since Java 11, unbinding may take effect only on the next select(). Thus there must be a select() between unbindings and performing new bindings.