### PR TITLE
Use SPDX identifier for license name

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,8 +81,8 @@
 
   <licenses>
     <license>
-      <name>Apache 2.0 License</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0</url>
+      <name>Apache-2.0</name>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>
   </licenses>


### PR DESCRIPTION
Use SPDX identifier for license name, like the Apache parent pom does. Also switch from http to https for the license URL