### PR TITLE
Remove ssl handshake initiation from postAdd method in SslFilter.java

### DIFF
--- a/mina-core/src/main/java/org/apache/mina/filter/ssl/SslFilter.java
+++ b/mina-core/src/main/java/org/apache/mina/filter/ssl/SslFilter.java
@@ -244,12 +244,6 @@ public class SslFilter extends IoFilterAdapter {
      */
     @Override
     public void onPostAdd(IoFilterChain parent, String name, NextFilter next) throws Exception {
-        IoSession session = parent.getSession();
-        
-        if (session.isConnected()) {
-            onConnected(next, session);
-        }
-        
         super.onPostAdd(parent, name, next);
     }
 


### PR DESCRIPTION
I'm getting exception when using SSL filter together with SOCKS proxy in quickfix library 2.2.0 with mina 2.2.2

java.lang.IllegalStateException
at org.apache.mina.proxy.filter.ProxyFilter.getProxyHandler(ProxyFilter.java:127) at org.apache.mina.proxy.filter.ProxyFilter.writeData(ProxyFilter.java:215) at org.apache.mina.proxy.filter.ProxyFilter.filterWrite(ProxyFilter.java:201) at org.apache.mina.core.filterchain.DefaultIoFilterChain.callPreviousFilterWrite(DefaultIoFilterChain.java:753) at org.apache.mina.core.filterchain.DefaultIoFilterChain.access$1500(DefaultIoFilterChain.java:49) at org.apache.mina.core.filterchain.DefaultIoFilterChain$EntryImpl$1.filterWrite(DefaultIoFilterChain.java:1146) at org.apache.mina.filter.ssl.SSLHandlerG0.write_handshake_loop(SSLHandler60.java:539) at org.apache.mina.filter.ssl.SSLHandlerG0.write_handshake(SSLHandler60.java:470) at org.apache.mina.filter.ssl.SSLHandlerG0.open(SSLHandlerG.java:143) at org.apache.mina.filter.ssl.SslFilter.onConnected(SslFilter.java:283) at org.apache.mina.filter.ssl.SslFilter.onPostAdd(SslFilter.java:250) at org.apache.mina.core.filterchain.DefaultIoFilterChain.register(DefaultIoFilterChain.java:473) at org.apache.mina.core.filterchain.DefaultIoFilterChain.addLast(DefaultIoFilterChain.java:234) at org.apache.mina.core.filterchainDefaultIoFilterChainBuilder.buildFilterChain(DefaultIoFilterChainBuilder.java:553) at quickfix.mina.CompositeIoFilterChainBuilder.buildFilterChain(CompositeIoFilterChainBuilder.java:42) at org.apache.mina.core.polling.AbstractPollingIoProcessor$Processor.addNow(AbstractPollingIoProcessor.java:832) at org.apache.mina.core.polling.AbstractPollingIoProcessor$Processor.handleNewSessions(AbstractPollingIoProcessor.java:752) at org.apache.mina.core.polling.AbstractPollingIoProcessor$Processor.run(AbstractPollingIoProcessor.java:652) at org.apache.mina.util.NamePreservingRunnable.run(NamePreservingRunnable.java:64) at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128) at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628) at java.base/java.lang.Thread.run(Thread.java:829)

After debugging, I found that:
1. Exception appereares because of missing handler in ProxyFilter object
2. ProxyFilter setup the handler only on SESSION_CREATED event
3. SslFilter in postAdd method tries to initiate handshake if session is open and writes data via nextFilter(ProxyFilter)