### PR TITLE
Binary compatibility with 2.0.X

### DIFF
--- a/mina-core/src/main/java/org/apache/mina/core/service/IoHandler.java
+++ b/mina-core/src/main/java/org/apache/mina/core/service/IoHandler.java
@@ -121,5 +121,7 @@ public interface IoHandler {
      * @param event The event to process
      * @throws Exception If we get an exception while processing the event 
      */
-    void event(IoSession session, FilterEvent event) throws Exception;
+    default void event(IoSession session, FilterEvent event) throws Exception {
+        // Nothing
+    }
 }


### PR DESCRIPTION
Make the method IoHandler.event() a default method.

This restores binary and source compatibility with 2.0.X except for classes that implement the IoHandler interface and also some other interface that would have a conflicting event() method. See JLS8 13.5.6.[1] However, since the event() method refers to the new type FilterEvent, there can be no such other conflicting method in existing code that was written and compiled against 2.0.X.

[1] https://docs.oracle.com/javase/specs/jls/se8/html/jls-13.html#jls-13.5.6