### PR TITLE
Make NioSession.getChannel() public

### DIFF
--- a/mina-core/src/main/java/org/apache/mina/transport/socket/nio/NioDatagramSession.java
+++ b/mina-core/src/main/java/org/apache/mina/transport/socket/nio/NioDatagramSession.java
@@ -75,7 +75,7 @@ class NioDatagramSession extends NioSession {
      * {@inheritDoc}
      */
     @Override
-    DatagramChannel getChannel() {
+    public DatagramChannel getChannel() {
         return (DatagramChannel) channel;
     }
 

--- a/mina-core/src/main/java/org/apache/mina/transport/socket/nio/NioSession.java
+++ b/mina-core/src/main/java/org/apache/mina/transport/socket/nio/NioSession.java
@@ -68,7 +68,7 @@ public abstract class NioSession extends AbstractIoSession {
     /**
      * @return The ByteChannel associated with this {@link IoSession} 
      */
-    abstract ByteChannel getChannel();
+    public abstract ByteChannel getChannel();
 
     /**
      * {@inheritDoc}

--- a/mina-core/src/main/java/org/apache/mina/transport/socket/nio/NioSocketSession.java
+++ b/mina-core/src/main/java/org/apache/mina/transport/socket/nio/NioSocketSession.java
@@ -83,7 +83,7 @@ class NioSocketSession extends NioSession {
      * {@inheritDoc}
      */
     @Override
-    SocketChannel getChannel() {
+    public SocketChannel getChannel() {
         return (SocketChannel) channel;
     }
 


### PR DESCRIPTION
Make `NioSession.getChannel()` public, as I am currently using reflection to access this method.

This is in the context of a complex (proprietary) framework I have at work.

CC @tomaswolf 
