### PR TITLE
[DIRMINA-1197] Add a Java CI workflow (branch `2.1.X`)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,80 @@
+# SPDX-License-Identifier: Apache-2.0
+name: Java CI
+
+on:
+  # Build only the production branches on push, so internal feature branches do not trigger a build twice (once on push, once on the pull request).
+  push:
+    # Restricts push builds to these branches, even if the workflow is copied to another branch.
+    branches:
+      - 2.0.X
+      - 2.1.X
+      - 2.2.X
+  # Build every pull request targeting the branch this workflow lives on.
+  pull_request:
+
+# Permissions are granted per job.
+permissions: { }
+
+# Check all pushes to production branches, but interrupt a PR job if a new commit is pushed.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+        java-version: [8, 11]
+        distribution: [temurin]
+        include:
+          # There is no Temurin JDK 8 release for macOS ARM.
+          - os: macos-latest
+            java-version: 8
+            distribution: zulu
+          - os: macos-latest
+            java-version: 11
+            distribution: temurin
+      fail-fast: false
+    name: Test JDK ${{ matrix.java-version }}, ${{ matrix.os }}
+
+    # Actions from the `actions` and `github` organizations are pinned to a major version tag rather than a commit SHA.
+    # This is a deliberate decision:
+    #
+    # - Those organizations have strong expertise in securing GitHub Actions.
+    # - A compromise of either organization would likely also compromise the GitHub Actions service itself, so pinning would not help.
+    # - These actions release frequently.
+    #
+    # The residual risk is deemed acceptable in exchange for less Dependabot churn across the maintained branches.
+    steps:
+
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          # Don't persist the GitHub token used to check out the repository.
+          persist-credentials: false
+
+      - name: Set up JDK
+        uses: actions/setup-java@v5
+        with:
+          java-version: ${{ matrix.java-version }}
+          distribution: ${{ matrix.distribution }}
+          cache: maven
+
+      - name: Test with Maven
+        shell: bash
+        run: |
+          mvn verify \
+          --show-version --batch-mode --errors --no-transfer-progress
+
+      # Upload the test results, even when the build failed.
+      - name: Upload test reports
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: "test-report-${{matrix.os}}-${{matrix.distribution}}-${{matrix.java-version}}-${{github.run_number}}-${{github.run_attempt}}"
+          # Don't warn or fail when no tests ran (e.g. a compilation failure).
+          if-no-files-found: ignore
+          path: |
+            **/target/surefire-reports

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -67,6 +67,7 @@ jobs:
         shell: bash
         run: |
           mvn verify \
+          -Pserial \
           --show-version --batch-mode --errors --no-transfer-progress
 
       # Upload the test results, even when the build failed.

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,9 +34,6 @@ jobs:
           - os: macos-latest
             java-version: 8
             distribution: zulu
-          - os: macos-latest
-            java-version: 11
-            distribution: temurin
       fail-fast: false
     name: Test JDK ${{ matrix.java-version }}, ${{ matrix.os }}
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,7 +26,8 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        java-version: [8, 11]
+        # Enforce Java 8 only, branches 2.0.X and 2.1.X won't build with any other versions
+        java-version: [8]
         distribution: [temurin]
         include:
           # There is no Temurin JDK 8 release for macOS ARM.


### PR DESCRIPTION
Same as #53 with a twist:

- There is Temurin JDK 8 for macOS ARM, so Zulu is used instead.