### PR TITLE
ci: cap the test job at 15 minutes

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,6 +23,9 @@ concurrency:
 jobs:
   test:
     runs-on: ${{ matrix.os }}
+    # Tests normally finish in 2-4 minutes; cap the job so a hung/deadlocked test fails fast
+    # instead of running until the 6-hour GitHub default.
+    timeout-minutes: 15
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]


### PR DESCRIPTION
## What

Adds a job-level `timeout-minutes: 15` to the `test` job in the Java CI workflow.

## Why

The `test` job had no timeout, so a hung or deadlocked test runs until GitHub's 6-hour default before the job fails (as seen on #57, where a test got into a deadlock). Tests normally finish in 2-4 minutes, so 15 minutes fails fast on a hang while leaving comfortable margin for the slowest matrix cells.

The cap is job-level, so it applies to every OS/JDK matrix combination. When it fires, the `if: always()` "Upload test reports" step still runs, preserving whatever surefire output exists to help locate the hang.